### PR TITLE
Add workfow for the Anbox Cloud Appliance

### DIFF
--- a/v1/anbox-cloud-appliance.yaml
+++ b/v1/anbox-cloud-appliance.yaml
@@ -12,7 +12,7 @@ instances:
       vendor-data: |
         runcmd:
         - apt update
-        - DEBIAN_FRONTEND=noninteractive apt purge -y linux-kvm linux-image-kvm linux-headers-kvm linux-image-* linux-headers-* linux-modules-*
+        - DEBIAN_FRONTEND=noninteractive apt purge -y linux-image-* linux-headers-* linux-modules-*
         - apt install -y linux-image-generic linux-headers-generic
         - apt autoremove -y
         - snap install --classic --channel=2.8/stable juju

--- a/v1/anbox-cloud-appliance.yaml
+++ b/v1/anbox-cloud-appliance.yaml
@@ -1,0 +1,21 @@
+description: Anbox Cloud Appliance
+version: latest
+
+instances:
+  anbox-cloud-appliance:
+    limits:
+      min-cpu: 4
+      min-mem: 4G
+      min-disk: 50G
+    timeout: 900
+    cloud-init:
+      vendor-data: |
+        runcmd:
+        - apt update
+        - DEBIAN_FRONTEND=noninteractive apt purge -y linux-kvm linux-image-kvm linux-headers-kvm linux-image-* linux-headers-* linux-modules-*
+        - apt install -y linux-image-generic linux-headers-generic
+        - apt autoremove -y
+        - snap install --classic --channel=2.8/stable juju
+        - snap install amc
+        - snap install --classic anbox-cloud-appliance
+        - reboot

--- a/v1/anbox-cloud-appliance.yaml
+++ b/v1/anbox-cloud-appliance.yaml
@@ -10,12 +10,23 @@ instances:
     timeout: 900
     cloud-init:
       vendor-data: |
+        snap:
+          commands:
+          - snap install --classic --channel=2.8/stable juju
+          - snap install amc
+          - snap install --classic anbox-cloud-appliance
+        
         runcmd:
-        - apt update
-        - DEBIAN_FRONTEND=noninteractive apt purge -y linux-image-* linux-headers-* linux-modules-*
-        - apt install -y linux-image-generic linux-headers-generic
-        - apt autoremove -y
-        - snap install --classic --channel=2.8/stable juju
-        - snap install amc
-        - snap install --classic anbox-cloud-appliance
-        - reboot
+        - |
+          # We're done if ashmem and binder are available
+          modprobe ashmem_linux && modprobe binder_linux && exit 0
+        
+          # else
+          apt-get update
+          env DEBIAN_FRONTEND=noninteractive apt purge -y linux-image-* linux-headers-* linux-modules-*
+          apt-get install -y linux-image-generic linux-headers-generic
+          apt-get autoremove -y
+        
+        power_state:
+          mode: reboot
+          condition: "! ( modprobe ashmem_linux && modprobe binder_linux )"


### PR DESCRIPTION
This installs everything necessary for the Anbox Cloud Appliance. In
essence this consists of a couple of snap packages to install but we
also have to switch to the generic kernel as the default kvm one doesn't
ship with the binder and ashmem kernel modules we require.