### PR TITLE
add workflow for docker

### DIFF
--- a/v1/docker-playground.yaml
+++ b/v1/docker-playground.yaml
@@ -1,0 +1,53 @@
+description: A playground environment with docker and related tools
+version: latest
+
+instances:
+  docker-playground:
+    image: 21.04
+    limits:
+      min-cpu: 2
+      min-mem: 4G
+      min-disk: 40G
+    cloud-init:
+      vendor-data: |
+        snap:
+          commands:
+          - snap install docker
+          - snap install yq
+
+        runcmd:
+        - |
+          # disable swap
+          sysctl vm.swappiness=0
+          echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
+
+        - |
+          # disable unnecessary services
+          systemctl disable man-db.timer man-db.service --now
+          systemctl disable apport.service apport-autoreport.service  --now
+          systemctl disable apt-daily.service apt-daily.timer --now
+          systemctl disable apt-daily-upgrade.service apt-daily-upgrade.timer --now
+          systemctl disable unattended-upgrades.service --now
+          systemctl disable motd-news.service motd-news.timer --now
+          systemctl disable bluetooth.target --now
+          systemctl disable ua-messaging.service ua-messaging.timer --now
+
+        - |
+          # various tools via apt
+          # gh cli
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+          apt-get -y update
+          apt-get -y install jq skopeo gh
+
+        - |
+          # dive, to easily browse image layers
+          wget https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb
+          dpkg -i ./dive_0.9.2_linux_amd64.deb
+
+        - |
+          # apt cleanup
+          apt-get autoremove -y
+
+        final_message: "The system is finally up, after $UPTIME seconds"

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -111,11 +111,6 @@ instances:
           systemctl disable ua-messaging.service ua-messaging.timer --now
 
         - |
-          # dive, to easily browse image layers
-          wget https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb
-          dpkg -i ./dive_0.9.2_linux_amd64.deb
-
-        - |
           # portainer, to easily manage containers
           # available on http://<IP>:9000
           docker run -d \

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -1,6 +1,13 @@
 description: A Docker environment with Portainer and related tools
 version: latest
 
+runs-on:
+- arm
+- arm64
+- power64
+- s390x
+- x86_64
+
 instances:
   docker:
     limits:

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -2,8 +2,7 @@ description: A playground environment with docker and related tools
 version: latest
 
 instances:
-  docker-playground:
-    image: 21.04
+  docker:
     limits:
       min-cpu: 2
       min-mem: 4G

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -123,6 +123,17 @@ instances:
           dpkg -i ./dive_0.9.2_linux_amd64.deb
 
         - |
+          # portainer, to easily manage containers
+          # available on http://<IP>:9000
+          docker run -d \
+            -p 9000:9000 \
+            --name=portainer \
+            --restart=always \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v portainer_data:/data \
+            portainer/portainer
+
+        - |
           # apt cleanup
           apt-get autoremove -y
 

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -9,11 +9,82 @@ instances:
       min-disk: 40G
     cloud-init:
       vendor-data: |
-        groups:
-        - docker
+        apt:
+          sources:
+            docker:
+              source: |
+                deb https://download.docker.com/linux/ubuntu $RELEASE stable
+              key: |
+                -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
+                lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
+                38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
+                L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
+                UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
+                cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
+                ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
+                vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
+                G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
+                XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
+                q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
+                tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
+                BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
+                v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
+                tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
+                jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
+                6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
+                XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
+                FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
+                g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
+                ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
+                9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
+                G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
+                FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
+                EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
+                M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
+                Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
+                w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
+                z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
+                eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
+                VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
+                1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
+                zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
+                pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
+                ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
+                BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
+                1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
+                YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
+                mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
+                KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
+                JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
+                cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
+                6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
+                U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
+                VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
+                irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
+                SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
+                QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
+                9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
+                24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
+                dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
+                Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
+                H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
+                /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
+                M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
+                xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
+                jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
+                YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
+                =0YYh
+                -----END PGP PUBLIC KEY BLOCK-----
+
+        packages:
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+
         snap:
           commands:
-          - snap install docker
           - snap install yq
 
         runcmd:

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -10,6 +10,7 @@ runs-on:
 
 instances:
   docker:
+    image: 21.10
     limits:
       min-cpu: 2
       min-mem: 4G

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -9,12 +9,18 @@ instances:
       min-disk: 40G
     cloud-init:
       vendor-data: |
+        groups:
+        - docker
         snap:
           commands:
           - snap install docker
           - snap install yq
 
         runcmd:
+        - |
+          # add `ubuntu` to the `docker` group
+          adduser ubuntu docker
+          
         - |
           # disable swap
           sysctl vm.swappiness=0

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -1,4 +1,4 @@
-description: A playground environment with docker and related tools
+description: A Docker environment with Portainer and related tools
 version: latest
 
 instances:
@@ -82,6 +82,8 @@ instances:
         - docker-ce
         - docker-ce-cli
         - containerd.io
+        - jq
+        - skopeo
 
         snap:
           commands:
@@ -91,7 +93,7 @@ instances:
         - |
           # add `ubuntu` to the `docker` group
           adduser ubuntu docker
-          
+
         - |
           # disable swap
           sysctl vm.swappiness=0
@@ -107,15 +109,6 @@ instances:
           systemctl disable motd-news.service motd-news.timer --now
           systemctl disable bluetooth.target --now
           systemctl disable ua-messaging.service ua-messaging.timer --now
-
-        - |
-          # various tools via apt
-          # gh cli
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-
-          apt-get -y update
-          apt-get -y install jq skopeo gh
 
         - |
           # dive, to easily browse image layers


### PR DESCRIPTION
This PR introduces a new workflow:

- `docker-playground`, which is useful for uploading image resources to charmcraft and basically anything related to oci images. Since docker iptables rules conflict with juju/lxd/multipass, it is convenient to have a separate instance for docker.