### PR TITLE
[charm-dev] bump versions

### DIFF
--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -80,7 +80,6 @@ instances:
         runcmd:
         - DEBIAN_FRONTEND=noninteractive apt remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme
         - DEBIAN_FRONTEND=noninteractive apt -y upgrade
-        - DEBIAN_FRONTEND=noninteractive apt -y autoremove
 
         - |
           # Install tox from pypi (v4) instead of apt (v3)

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -45,19 +45,21 @@ instances:
         - ripgrep
         - gnome-keyring
         - kitty-terminfo
+        - just
 
         snap:
           commands:
           # Juju 3.6 is an LTS.
           # https://juju.is/docs/juju/roadmap
-          - snap install juju --channel=3.5/stable
-          - snap install microk8s --channel=1.30-strict/stable
+          - snap install juju --channel=3.6/stable
+          - snap install microk8s --channel=1.31-strict/stable
           - snap alias microk8s.kubectl kubectl
           - snap alias microk8s.kubectl k
           - snap install --classic charmcraft
           - snap install --classic rockcraft
           - snap install jhack --channel=latest/stable
           - snap install yq
+          - snap install astral-uv --classic
           - snap refresh
 
         write_files:


### PR DESCRIPTION
In this PR:
- Bumped Juju to 3.6 (LTS), MicroK8s to 1.31.

Drive-by fixes:
- Added new tools to address current practices: uv, just
- Dropped "autoremove" because it was uninstalling gnome-keyring, which is needed for charmcraft to function.

Tested manually with:
```bash
yq '.instances."charm-dev"."cloud-init"."vendor-data"' v1/charm-dev.yaml > charm-dev-cloud-init.yaml 
multipass launch noble --cloud-init ./charm-dev-cloud-init.yaml --name test --memory 8G --cpus 4 --disk 100G
```
and deploying cos-lite.